### PR TITLE
fix corner-case bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .cpcache
 .nrepl-port
 .swp
+.clj-kondo/
+.lsp/

--- a/src/dvliman/demo.clj
+++ b/src/dvliman/demo.clj
@@ -1,29 +1,35 @@
 (ns dvliman.demo
   (:require [reitit.ring :as ring]
-            [ring.util.response :as response]))
+            [ring.util.response :as response])
+  (:import [clojure.lang PersistentQueue]
+           [java.util UUID]))
 
-(defn update-state [state bucket timestamp capacity interval-ms]
+(defn prune-queue [requests-queue cutoff]
+  (loop [q requests-queue]
+    (if-let [old-timestamp (:ts (first q))]
+      (if (<= old-timestamp cutoff)
+        (recur (pop q))
+        q)
+      q)))
+
+(defn update-state [state bucket entry
+                    {:keys [capacity interval-ms]}]
   (if-let [requests-queue (get state bucket)]
-    (let [pruned-queue (loop [q requests-queue]
-                         (if-let [old-timestamp (first q)]
-                           (if (<= old-timestamp (- timestamp interval-ms))
-                             (recur (pop q))
-                             q)
-                           q))]
+    (let [pruned-queue (prune-queue requests-queue (- (:ts entry) interval-ms))]
       (if (>= (count pruned-queue) capacity)
         (assoc state bucket pruned-queue)
-        (assoc state bucket (conj pruned-queue timestamp))))
-    (assoc state bucket (conj (clojure.lang.PersistentQueue/EMPTY) timestamp))))
+        (assoc state bucket (conj pruned-queue entry))))
+    (assoc state bucket (conj (PersistentQueue/EMPTY) entry))))
 
-(defn wrap-rate-limit [{:keys [capacity interval-ms bucket-fn]}]
+(defn wrap-rate-limit [{:keys [bucket-fn] :as opts}]
   (let [state (atom {})]
     (fn [handler]
       (fn [request]
         (let [bucket (bucket-fn request)
-              now (System/currentTimeMillis)
-              new-state (swap! state
-                               #(update-state % bucket now capacity interval-ms))]
-          (if (not= now (last (get new-state bucket)))
+              entry {:ts (System/currentTimeMillis)
+                     :id (UUID/randomUUID)}]
+          (swap! state #(update-state % bucket entry opts))
+          (if (not= (:id entry) (:id (last (get @state bucket))))
             {:status 429 :body {:error :exceeded-rate-limit}}
             (handler request)))))))
 
@@ -41,8 +47,8 @@
 
 (def rate-limit-option
   {:capacity 1
-   :interval-ms (* 1 1000)
-   :bucket-fn #(:remote-addr %)}) ;; by IP address
+   :interval-ms 1000
+   :bucket-fn :remote-addr}) ;; by IP address
 
 (def app
   (ring/ring-handler

--- a/test/dvliman/demo_test.clj
+++ b/test/dvliman/demo_test.clj
@@ -20,7 +20,6 @@
   (testing "2 requests (same IP) with capacity of 1, 1 should be rejected"
     (let [router (make-test-router default-options)]
       (is (= 200 (:status (-> (mock/request :post "/login") router))))
-      (Thread/sleep 1)
       (is (= 429 (:status (-> (mock/request :post "/login") router)))))))
 
 (deftest reset-after-interval-window
@@ -42,5 +41,4 @@
   (testing "rate limit middleware applies to all urls"
     (let [router (make-test-router default-options)]
       (is (= 200 (:status (-> (mock/request :post "/login") router))))
-      (Thread/sleep 1)
       (is (= 429 (:status (-> (mock/request :get "/health") router)))))))


### PR DESCRIPTION
Problem: tests wouldn't work w/o an artificial sleep.

Cause: From the same client, any request at the same millisecond as the previous request fools the server into thinking the new request was added to the queue.  It may not have been added to the queue due to capacity.

Solution: I chose to pair a uuid with the timestamp, and compare to that instead.


I also simplified the code a bit.